### PR TITLE
Pin berkshelf gem to 4.3.3

### DIFF
--- a/config/cookbooks/raspberry/recipes/default.rb
+++ b/config/cookbooks/raspberry/recipes/default.rb
@@ -39,7 +39,9 @@ cookbook_file "/etc/init.d/update_chef" do
 end
 
 apt_package 'ruby-dev'
-gem_package 'berkshelf'
+gem_package 'berkshelf' do
+    version '4.3.3'
+end
 
 service "update_chef" do
     supports :status => true, :restart => true, :reload => true


### PR DESCRIPTION
Later versions have an indirect dependency which cause an error:

> buff-ruby_engine requires Ruby version >= 2.2.0

The Wheezy repo for Raspberry Pi only includes ruby 2.1 and before. Installing ruby 2.3 is possible, but it is a challenge.